### PR TITLE
Update erp.py

### DIFF
--- a/lib/erp.py
+++ b/lib/erp.py
@@ -107,7 +107,7 @@ def vu2erp(*,
 
     n1 = np.asarray([proj_shape[0], proj_shape[1]]).reshape(shape)
 
-    nm = vu * n1
+    nm = vu * (n1 - 1)
     nm = np.floor(nm)
     return nm.astype(int)
 


### PR DESCRIPTION
Fix vu2erp.
The normalized coordinate matrix must be applied to the image dimension minus 1